### PR TITLE
Use environment variables for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A simple Telegram bot to manage a paper book library using QR codes. Built with 
 pip install python-telegram-bot==20.*
 ```
 
-2. Edit `config.py` and set your bot token and administrator Telegram IDs.
+2. Copy `config_template.py` to `config.py` (or create it yourself) and
+   provide the required environment variables.
 
 ## Usage
 
@@ -24,12 +25,19 @@ Users register via `/start` and can take or return books using the menu buttons.
 Use the `/menu` command at any time to show the main keyboard again.
 All data is stored in `data/users.json` and `data/books.json`.
 
+### Environment Variables
+
+Set the following variables in your shell or `.env` file:
+
+- `BOT_TOKEN` – Telegram bot token obtained from BotFather.
+- `ADMIN_IDS` – comma-separated list of Telegram user IDs that have admin access.
+
 ## Project Structure
 
 - `main.py` – bot startup script.
 - `handlers/` – handlers for user and admin actions.
 - `data/` – JSON files with users and books.
-- `config.py` – configuration with bot token and admin IDs.
+- `config.py` – configuration that reads the token and admin IDs from environment variables.
 - `utils.py` – utility functions for data access and checks.
 
 

--- a/config.py
+++ b/config.py
@@ -1,2 +1,5 @@
-BOT_TOKEN = 8155626371:AAFct2z_XvBaIfaYiNFdSnmuizPp9R0ITV4
-ADMIN_IDS = "BrutalChA"
+import os
+
+# Load bot credentials from environment variables
+BOT_TOKEN = os.getenv("BOT_TOKEN")
+ADMIN_IDS = [int(uid) for uid in os.getenv("ADMIN_IDS", "").split(",") if uid]

--- a/config_template.py
+++ b/config_template.py
@@ -1,0 +1,7 @@
+"""Example configuration loaded from environment variables."""
+
+import os
+
+BOT_TOKEN = os.getenv("BOT_TOKEN")
+# Comma-separated list of Telegram user IDs with admin rights
+ADMIN_IDS = [int(uid) for uid in os.getenv("ADMIN_IDS", "").split(",") if uid]


### PR DESCRIPTION
## Summary
- avoid hard-coded credentials by reading from `os.getenv`
- document required environment variables in README
- add `config_template.py` example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687f70c49468832ab35470193ee8b713