### PR TITLE
Add config template and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore configuration containing secrets
+config.py
+
+# Ignore compiled Python files
+*.pyc
+
+# Ignore JSON data files
+data/*.json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple Telegram bot to manage a paper book library using QR codes. Built with 
 pip install python-telegram-bot==20.*
 ```
 
-2. Edit `config.py` and set your bot token and administrator Telegram IDs.
+2. Copy `config.py.example` to `config.py` and set your bot token and administrator Telegram IDs.
 
 ## Usage
 
@@ -30,6 +30,7 @@ All data is stored in `data/users.json` and `data/books.json`.
 - `handlers/` – handlers for user and admin actions.
 - `data/` – JSON files with users and books.
 - `config.py` – configuration with bot token and admin IDs.
+- `config.py.example` – template to create your own `config.py`.
 - `utils.py` – utility functions for data access and checks.
 
 

--- a/config.py.example
+++ b/config.py.example
@@ -1,0 +1,7 @@
+# Example configuration for QR Library Telegram Bot
+
+# Replace with your bot token obtained from BotFather
+BOT_TOKEN = "YOUR_BOT_TOKEN_HERE"
+
+# Comma-separated list or Python list of Telegram user IDs for admin access
+ADMIN_IDS = "123456789"


### PR DESCRIPTION
## Summary
- track secrets via `.gitignore`
- explain how to copy the config template in the README
- provide an example configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687f70c16628832a92910d0bf4bf0a60