### PR TITLE
Add all books listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Users register via `/start` and can take or return books using the menu buttons.
 When starting the bot you will see a short welcome message describing its purpose.
 During any step you can press the "↩️ Назад" button to cancel the current action
 and return to the main menu. Use the `/menu` command at any time to show the main keyboard again.
+Use the "📖 Все книги" button to see a list of all books with their current status.
 All data is stored in `data/users.json` and `data/books.json`.
 
 ## Project Structure

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -11,11 +11,11 @@ CANCEL_KEYBOARD = ReplyKeyboardMarkup([[CANCEL_TEXT]], resize_keyboard=True, one
 LAST_NAME, FIRST_NAME, ORGANIZATION = range(3)
 
 USER_KEYBOARD = ReplyKeyboardMarkup(
-    [["🔍 Взять книгу", "📤 Вернуть книгу"], ["📚 Мои книги"]],
+    [["🔍 Взять книгу", "📤 Вернуть книгу"], ["📚 Мои книги"], ["📖 Все книги"]],
     resize_keyboard=True,
 )
 ADMIN_KEYBOARD = ReplyKeyboardMarkup(
-    [["➕ Добавить книгу", "📊 Отчёт по библиотеке"], ["🔁 Сброс книги", "👤 Список пользователей"]],
+    [["➕ Добавить книгу", "📊 Отчёт по библиотеке"], ["🔁 Сброс книги", "👤 Список пользователей"], ["📖 Все книги"]],
     resize_keyboard=True,
 )
 


### PR DESCRIPTION
## Summary
- show a new `📖 Все книги` option in user and admin menus
- implement handler to list all books with account and date
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687f7c810014832a87b670e98bde902a