### PR TITLE
Add office-specific management

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -3,5 +3,11 @@
 # Replace with your bot token obtained from BotFather
 BOT_TOKEN = "YOUR_BOT_TOKEN_HERE"
 
-# Comma-separated list or Python list of Telegram user IDs for admin access
-ADMIN_IDS = "123456789"
+# List of global administrator Telegram IDs
+ADMIN_IDS = [123456789]
+
+# Mapping of office name to administrator IDs
+OFFICES = {
+    "Moscow": {"admins": [123456789]},
+    "Berlin": {"admins": [987654321]},
+}


### PR DESCRIPTION
## Summary
- support multiple offices with admin per office
- add office to users and books
- filter book operations by office
- update registration flow to choose office

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687f8df30484832abdbb282139a73751