### PR TITLE
Add Dockerfile and container docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -37,5 +37,22 @@ All data is stored in `data/users.json` and `data/books.json`.
 - `config.py.example` – template to create your own `config.py`.
 - `utils.py` – utility functions for data access and checks.
 
+## Docker
+
+Build the image locally:
+
+```bash
+docker build -t hrbook:latest .
+```
+
+Tag the resulting image and push it to Yandex Container Registry:
+
+```bash
+docker tag hrbook:latest cr.yandex/<registry>/<image>:<tag>
+docker push cr.yandex/<registry>/<image>:<tag>
+```
+
+Reference the pushed tag in your deployment configuration so that the correct
+image version is used.
 
 


### PR DESCRIPTION
## Summary
- add a Dockerfile using python:3.10-slim
- document how to build, tag and push the container image

## Testing
- `python -m py_compile main.py handlers/*.py utils.py`

------
https://chatgpt.com/codex/tasks/task_b_687f9b8e5b50832aa57817a692864594