### PR TITLE
Fix back button handling and office selection

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,2 +1,10 @@
 BOT_TOKEN = "8155626371:AAFct2z_XvBaIfaYiNFdSnmuizPp9R0ITV4"
 ADMIN_IDS = ["7007125219"]
+
+# Offices available for registration. Keys are the office names that will be
+# presented to the user during the /start flow. Each office can optionally
+# define administrators specific to that office.
+OFFICES = {
+    "SokolGora": {"admins": ["1000131763"]},
+    "Central": {"admins": []},
+}

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -132,15 +132,26 @@ def get_handlers() -> list:
         ConversationHandler(
             entry_points=[MessageHandler(filters.Regex("^➕ Добавить книгу$"), add_book_start)],
             states={
-                ADD_QR: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_book_get_qr)],
-                ADD_TITLE: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_book_get_title)],
+                ADD_QR: [
+                    MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, add_book_get_qr),
+                ],
+                ADD_TITLE: [
+                    MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, add_book_get_title),
+                ],
             },
             fallbacks=[MessageHandler(filters.Regex(CANCEL_RE), cancel_action)],
         ),
         MessageHandler(filters.Regex("^📊 Отчёт по библиотеке$"), report),
         ConversationHandler(
             entry_points=[MessageHandler(filters.Regex("^🔁 Сброс книги$"), reset_book_start)],
-            states={RESET_QR: [MessageHandler(filters.TEXT & ~filters.COMMAND, reset_book_get_qr)]},
+            states={
+                RESET_QR: [
+                    MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, reset_book_get_qr),
+                ]
+            },
             fallbacks=[MessageHandler(filters.Regex(CANCEL_RE), cancel_action)],
         ),
         MessageHandler(filters.Regex("^👤 Список пользователей$"), list_users),

--- a/handlers/books.py
+++ b/handlers/books.py
@@ -128,12 +128,22 @@ def get_handlers() -> list:
     return [
         ConversationHandler(
             entry_points=[MessageHandler(filters.Regex("^🔍 Взять книгу$"), take_book_start)],
-            states={TAKE_QR: [MessageHandler(filters.TEXT & ~filters.COMMAND, take_book_get_qr)]},
+            states={
+                TAKE_QR: [
+                    MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, take_book_get_qr),
+                ]
+            },
             fallbacks=[MessageHandler(filters.Regex(CANCEL_RE), cancel_action)],
         ),
         ConversationHandler(
             entry_points=[MessageHandler(filters.Regex("^📤 Вернуть книгу$"), return_book_start)],
-            states={RETURN_QR: [MessageHandler(filters.TEXT & ~filters.COMMAND, return_book_get_qr)]},
+            states={
+                RETURN_QR: [
+                    MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, return_book_get_qr),
+                ]
+            },
             fallbacks=[MessageHandler(filters.Regex(CANCEL_RE), cancel_action)],
         ),
         MessageHandler(filters.Regex("^📚 Мои книги$"), my_books),

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -9,7 +9,8 @@ from utils import get_user, register_user, is_admin
 CANCEL_TEXT = "\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434"
 # Accept minor variations of the back button text so the handler works even if
 # users type "Назад" manually or the arrow symbol differs.
-CANCEL_RE = r"(?i)^\u21a9\ufe0f?\s*назад$"
+# Accept "Назад" typed manually or with the arrow from the button.
+CANCEL_RE = r"(?i)^(?:\u21a9\ufe0f?\s*)?назад$"
 CANCEL_KEYBOARD = ReplyKeyboardMarkup(
     [[CANCEL_TEXT]], resize_keyboard=True, one_time_keyboard=True
 )
@@ -109,9 +110,18 @@ def get_handler() -> ConversationHandler:
     return ConversationHandler(
         entry_points=[CommandHandler("start", start)],
         states={
-            LAST_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, get_last_name)],
-            FIRST_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, get_first_name)],
-            OFFICE: [MessageHandler(filters.TEXT & ~filters.COMMAND, get_office)],
+            LAST_NAME: [
+                MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                MessageHandler(filters.TEXT & ~filters.COMMAND, get_last_name),
+            ],
+            FIRST_NAME: [
+                MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                MessageHandler(filters.TEXT & ~filters.COMMAND, get_first_name),
+            ],
+            OFFICE: [
+                MessageHandler(filters.Regex(CANCEL_RE), cancel_action),
+                MessageHandler(filters.TEXT & ~filters.COMMAND, get_office),
+            ],
         },
         fallbacks=[MessageHandler(filters.Regex(CANCEL_RE), cancel_action)],
     )


### PR DESCRIPTION
## Summary
- allow Back button text without the arrow
- show office list by defining `OFFICES`
- process back button presses before other handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: E501 line too long, F401 etc.)*

------
https://chatgpt.com/codex/tasks/task_b_687fa839eeec832aa2f2bf73f61c729b