### PR TITLE
Add Telegram bot tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,12 @@ docker push cr.yandex/<registry>/<image>:<tag>
 Reference the pushed tag in your deployment configuration so that the correct
 image version is used.
 
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+import json
+from datetime import datetime
+import itertools
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+import telegram
+from telegram import User, Chat, Message, MessageEntity
+from telegram.ext import Application
+
+import config
+import utils
+from handlers.start import get_handler as start_handler, get_menu_handler
+from handlers.books import get_handlers as books_handlers
+from handlers.admin import get_handlers as admin_handlers
+
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app(tmp_path, monkeypatch):
+    # configure temporary data directory
+    monkeypatch.setattr(utils, "DATA_DIR", tmp_path)
+    (tmp_path / "users.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "books.json").write_text("[]", encoding="utf-8")
+
+    # minimal config
+    monkeypatch.setattr(config, "BOT_TOKEN", "TEST")
+    monkeypatch.setattr(config, "ADMIN_IDS", ["1"])
+    monkeypatch.setattr(config, "OFFICES", {"Main": {"admins": ["1"]}})
+
+    sent_messages = []
+
+    async def fake_do_post(self, endpoint, data, *args, **kwargs):
+        if endpoint == "sendMessage":
+            sent_messages.append(data["text"])
+            return {
+                "message_id": len(sent_messages),
+                "date": 0,
+                "chat": {"id": data["chat_id"], "type": "private"},
+                "text": data["text"],
+            }
+        return {"ok": True, "result": True}
+
+    async def dummy_initialize(self):
+        self._initialized = True
+        self._bot_user = User(
+            id=999, is_bot=True, first_name="TestBot", username="testbot"
+        )
+
+    monkeypatch.setattr(telegram.Bot, "_do_post", fake_do_post)
+    monkeypatch.setattr(telegram.Bot, "initialize", dummy_initialize)
+
+    application = Application.builder().token("TEST").build()
+    application.add_handler(start_handler())
+    application.add_handler(get_menu_handler())
+    for h in books_handlers():
+        application.add_handler(h)
+    for h in admin_handlers():
+        application.add_handler(h)
+
+    await application.initialize()
+    yield application, sent_messages, tmp_path
+    await application.shutdown()
+
+
+_id_gen = itertools.count(1)
+
+
+def make_update(app, text, user_id=1):
+    user = User(id=user_id, is_bot=False, first_name="Test")
+    chat = Chat(id=user_id, type="private")
+    entities = None
+    if text.startswith("/"):
+        entities = [MessageEntity(type="bot_command", offset=0, length=len(text))]
+    msg = Message(
+        message_id=next(_id_gen),
+        date=datetime.now(),
+        chat=chat,
+        from_user=user,
+        text=text,
+        entities=entities,
+    )
+    msg._bot = app.bot
+    return telegram.Update(update_id=next(_id_gen), message=msg)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,87 @@
+import json
+import pytest
+
+from handlers.start import LAST_NAME, FIRST_NAME, OFFICE
+import utils
+from conftest import make_update
+
+
+@pytest.mark.asyncio
+async def test_registration_flow(app):
+    application, sent, tmp = app
+    # start command
+    await application.process_update(make_update(application, "/start", user_id=1))
+    assert sent[-1] == "Введите вашу фамилию:"
+    # last name
+    await application.process_update(make_update(application, "Ivanov"))
+    assert sent[-1] == "Введите ваше имя:"
+    # first name
+    await application.process_update(make_update(application, "Ivan"))
+    assert sent[-1] == "Выберите офис:"
+    await application.process_update(make_update(application, "Main"))
+    assert sent[-1] == "✅ Регистрация успешна."
+    data = json.loads((tmp / "users.json").read_text())
+    assert data[0]["first_name"] == "Ivan"
+    assert data[0]["office"] == "Main"
+
+
+@pytest.mark.asyncio
+async def test_take_and_return_book(app):
+    application, sent, tmp = app
+    # register user
+    await application.process_update(make_update(application, "/start"))
+    await application.process_update(make_update(application, "Last"))
+    await application.process_update(make_update(application, "First"))
+    await application.process_update(make_update(application, "Main"))
+    # prepare book
+    books = [
+        {
+            "qr_code": "qr1",
+            "title": "Book",
+            "status": "available",
+            "taken_by": None,
+            "taken_date": None,
+            "office": "Main",
+        }
+    ]
+    (tmp / "books.json").write_text(json.dumps(books), encoding="utf-8")
+    # take book
+    await application.process_update(make_update(application, "🔍 Взять книгу"))
+    assert sent[-1] == "Отправьте QR-код книги:"
+    await application.process_update(make_update(application, "qr1"))
+    assert any("успешно" in m for m in sent[-2:])
+    books = json.loads((tmp / "books.json").read_text())
+    assert books[0]["status"] == "taken"
+    # return book
+    await application.process_update(make_update(application, "📤 Вернуть книгу"))
+    assert sent[-1] == "Отправьте QR-код книги для возврата:"
+    await application.process_update(make_update(application, "qr1"))
+    books = json.loads((tmp / "books.json").read_text())
+    assert books[0]["status"] == "available"
+
+
+@pytest.mark.asyncio
+async def test_admin_operations(app):
+    application, sent, tmp = app
+    # admin registration
+    await application.process_update(make_update(application, "/start", user_id=1))
+    await application.process_update(make_update(application, "Admin"))
+    await application.process_update(make_update(application, "User"))
+    await application.process_update(make_update(application, "Main"))
+    # add book as admin
+    await application.process_update(make_update(application, "➕ Добавить книгу"))
+    assert sent[-1] == "Отправьте QR-код новой книги:"
+    await application.process_update(make_update(application, "newqr"))
+    assert sent[-1] == "Введите название книги:"
+    await application.process_update(make_update(application, "New Book"))
+    books = json.loads((tmp / "books.json").read_text())
+    assert books[0]["qr_code"] == "newqr"
+    # non-admin attempt
+    await application.process_update(make_update(application, "/start", user_id=2))
+    await application.process_update(make_update(application, "User", user_id=2))
+    await application.process_update(make_update(application, "U", user_id=2))
+    await application.process_update(make_update(application, "Main", user_id=2))
+    await application.process_update(
+        make_update(application, "➕ Добавить книгу", user_id=2)
+    )
+    assert sent[-1] == "Недостаточно прав."


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for the bot
- patch Telegram API calls in tests
- test registration, book take/return and admin permissions
- mention running `pytest` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687faf4c31b8832aa03bd9bcacd85f37