### PR TITLE
Implement office change feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,11 @@ import logging
 from telegram.ext import Application
 
 import config
-from handlers.start import get_handler as start_handler, get_menu_handler
+from handlers.start import (
+    get_handler as start_handler,
+    get_menu_handler,
+    get_change_office_handler,
+)
 from handlers.books import get_handlers as books_handlers
 from handlers.admin import get_handlers as admin_handlers
 
@@ -19,6 +23,7 @@ def main() -> None:
 
     application.add_handler(start_handler())
     application.add_handler(get_menu_handler())
+    application.add_handler(get_change_office_handler())
     for handler in books_handlers():
         application.add_handler(handler)
     for handler in admin_handlers():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,11 @@ from telegram.ext import Application
 
 import config
 import utils
-from handlers.start import get_handler as start_handler, get_menu_handler
+from handlers.start import (
+    get_handler as start_handler,
+    get_menu_handler,
+    get_change_office_handler,
+)
 from handlers.books import get_handlers as books_handlers
 from handlers.admin import get_handlers as admin_handlers
 
@@ -32,7 +36,11 @@ async def app(tmp_path, monkeypatch):
     # minimal config
     monkeypatch.setattr(config, "BOT_TOKEN", "TEST")
     monkeypatch.setattr(config, "ADMIN_IDS", ["1"])
-    monkeypatch.setattr(config, "OFFICES", {"Main": {"admins": ["1"]}})
+    monkeypatch.setattr(
+        config,
+        "OFFICES",
+        {"Main": {"admins": ["1"]}, "Alt": {"admins": []}},
+    )
 
     sent_messages = []
 
@@ -59,6 +67,7 @@ async def app(tmp_path, monkeypatch):
     application = Application.builder().token("TEST").build()
     application.add_handler(start_handler())
     application.add_handler(get_menu_handler())
+    application.add_handler(get_change_office_handler())
     for h in books_handlers():
         application.add_handler(h)
     for h in admin_handlers():

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -85,3 +85,19 @@ async def test_admin_operations(app):
         make_update(application, "➕ Добавить книгу", user_id=2)
     )
     assert sent[-1] == "Недостаточно прав."
+
+
+@pytest.mark.asyncio
+async def test_change_office(app):
+    application, sent, tmp = app
+    # register user
+    await application.process_update(make_update(application, "/start"))
+    await application.process_update(make_update(application, "Last"))
+    await application.process_update(make_update(application, "First"))
+    await application.process_update(make_update(application, "Main"))
+
+    await application.process_update(make_update(application, "🏢 Сменить офис"))
+    assert sent[-1] == "Выберите офис:"
+    await application.process_update(make_update(application, "Alt"))
+    data = json.loads((tmp / "users.json").read_text())
+    assert data[0]["office"] == "Alt"

--- a/utils.py
+++ b/utils.py
@@ -79,6 +79,19 @@ def register_user(
     return user
 
 
+def update_user_office(user_id: int, office: str) -> Optional[Dict[str, Any]]:
+    """Update the office for an existing user."""
+    users = load_json("users.json")
+    for usr in users:
+        if usr.get("telegram_id") == user_id:
+            usr["office"] = office
+            usr["role"] = "admin" if is_admin(user_id, office) else "user"
+            save_json("users.json", users)
+            log_action("update_office", {"user_id": user_id, "office": office})
+            return usr
+    return None
+
+
 def get_book_by_qr(qr: str) -> Optional[Dict[str, Any]]:
     books = load_json("books.json")
     for book in books:


### PR DESCRIPTION
## Summary
- allow changing a user's office
- update keyboards with a button to change office
- add conversation handler for office updates
- expose new handler in main application
- extend tests to cover changing office

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fb6410718832a8b44af7828543723