### PR TITLE
Fix QR recognition from images

### DIFF
--- a/handlers/books.py
+++ b/handlers/books.py
@@ -19,6 +19,7 @@ from utils import (
     load_json,
     get_user,
     get_books_by_office,
+    extract_qr_from_update,
 )
 from .start import (
     USER_KEYBOARD,
@@ -41,7 +42,7 @@ async def take_book_start(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 async def take_book_get_qr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user = get_user(update.effective_user.id)
     office = user.get("office") if user else None
-    qr = (update.message.text or update.message.caption or "").strip()
+    qr = await extract_qr_from_update(update, context.bot)
     if not qr:
         await update.message.reply_text(
             "Не удалось распознать QR-код. Отправьте текстовый код.",
@@ -81,7 +82,7 @@ async def return_book_start(update: Update, context: ContextTypes.DEFAULT_TYPE) 
 async def return_book_get_qr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user = get_user(update.effective_user.id)
     office = user.get("office") if user else None
-    qr = (update.message.text or update.message.caption or "").strip()
+    qr = await extract_qr_from_update(update, context.bot)
     if not qr:
         await update.message.reply_text(
             "Не удалось распознать QR-код. Отправьте текстовый код.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-telegram-bot==20.*
+opencv-python-headless

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,3 +97,20 @@ def make_update(app, text, user_id=1):
     )
     msg._bot = app.bot
     return telegram.Update(update_id=next(_id_gen), message=msg)
+
+
+def make_photo_update(app, user_id=1):
+    """Return an Update with a dummy photo message."""
+    user = User(id=user_id, is_bot=False, first_name="Test")
+    chat = Chat(id=user_id, type="private")
+    photo = telegram.PhotoSize(file_id="file-id", file_unique_id="file-uid", width=1, height=1)
+    photo._bot = app.bot
+    msg = Message(
+        message_id=next(_id_gen),
+        date=datetime.now(),
+        chat=chat,
+        from_user=user,
+        photo=[photo],
+    )
+    msg._bot = app.bot
+    return telegram.Update(update_id=next(_id_gen), message=msg)


### PR DESCRIPTION
## Summary
- support QR code detection in attached images
- require opencv-python-headless
- test photo-based QR detection

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fc9aa3ddc832a88a1199045f1adb1