### PR TITLE
Fix missing psycopg2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ python-telegram-bot==20.*
 opencv-python-headless
 python-dotenv
 qrcode
+psycopg2-binary
 


### PR DESCRIPTION
## Summary
- include psycopg2-binary in requirements

## Testing
- `pip install -r requirements.txt`
- `pip install pytest_asyncio`
- `pip install Pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fe86e082c832a9c54d38a42b44b36