### PR TITLE
Remove default DB credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,11 @@ ADMIN_IDS=7007125219
 
 # Administrator IDs for specific offices (comma separated)
 OFFICE_SOKOLGORA_ADMINS=1000131763
+
+# PostgreSQL connection settings
+# Example values shown below, adjust for your environment
+DB_NAME=hrdb
+DB_USER=hrbot
+DB_PASSWORD=secret
+DB_HOST=localhost
+DB_PORT=5432

--- a/db.py
+++ b/db.py
@@ -2,11 +2,13 @@ import os
 from contextlib import contextmanager
 import psycopg2
 
-DB_NAME = os.getenv("DB_NAME", "HRbase")
-DB_USER = os.getenv("DB_USER", "Sergey")
-DB_PASSWORD = os.getenv("DB_PASSWORD", "Qwerty455")
-DB_HOST = os.getenv("DB_HOST", "amvera-sergey13683-cnpg-hrbase-rw")
-DB_PORT = int(os.getenv("DB_PORT", "5432"))
+# Required database connection settings. These environment variables must be
+# defined or a ``KeyError`` will be raised on import.
+DB_NAME = os.environ["DB_NAME"]
+DB_USER = os.environ["DB_USER"]
+DB_PASSWORD = os.environ["DB_PASSWORD"]
+DB_HOST = os.environ["DB_HOST"]
+DB_PORT = int(os.environ["DB_PORT"])
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
- use required environment variables for database config
- document PostgreSQL variables in `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687ff39ea6b4832a8173b7ceed992d11