### PR TITLE
Load env vars automatically

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,8 +10,16 @@ from dotenv import load_dotenv
 # Ensure environment variables are loaded when the application is started from
 # any working directory. We look for a ``.env`` file located next to this module
 # (i.e. in the project root) and load it if present.
-dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
-load_dotenv(dotenv_path)
+base_dir = os.path.dirname(__file__)
+dotenv_path = os.path.join(base_dir, ".env")
+example_path = os.path.join(base_dir, ".env.example")
+
+# Load variables from .env if present. If not, fall back to .env.example so the
+# bot can run with the example configuration out of the box.
+if os.path.exists(dotenv_path):
+    load_dotenv(dotenv_path)
+elif os.path.exists(example_path):
+    load_dotenv(example_path)
 
 
 def _parse_ids(value: str) -> List[str]:

--- a/db.py
+++ b/db.py
@@ -1,6 +1,14 @@
 import os
 from contextlib import contextmanager
+
+from dotenv import load_dotenv
 import psycopg2
+
+# Load environment variables from a .env file located next to this module.
+# This ensures database configuration is available when the module is imported.
+dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
+if os.path.exists(dotenv_path):
+    load_dotenv(dotenv_path)
 
 # Required database connection settings. These environment variables must be
 # defined or a ``KeyError`` will be raised on import.


### PR DESCRIPTION
## Summary
- load env var files in `config.py`
- ensure `db.py` also loads the `.env` file so DB settings are available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ffbd6d33c832aa3cd181c45b9e19c