### PR TITLE
Gracefully handle DB init failures

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,10 @@ def main() -> None:
     )
     application = Application.builder().token(config.BOT_TOKEN).build()
 
-    db.init_db()
+    try:
+        db.init_db()
+    except Exception as exc:
+        logging.error("Database unavailable: %s", exc)
 
     application.add_handler(start_handler())
     application.add_handler(get_menu_handler())


### PR DESCRIPTION
## Summary
- protect `db.init_db()` with error handling so the bot can start without a database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688001168f04832a82ebcd35643dac01