### PR TITLE
Prevent multiple bot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,12 @@ Run the unit tests with:
 pytest
 ```
 
+## Avoiding 409 Conflict Errors
+
+Telegram returns `409 Conflict` if more than one instance of the bot polls for
+updates using the same token. The startup script now creates a lock file at
+`/tmp/hrbook_bot.lock` to ensure only a single bot process runs. If you see an
+error similar to `terminated by other getUpdates request`, make sure no other
+process is running and remove the lock file if necessary.
+
 


### PR DESCRIPTION
## Summary
- add a lock file when running `main.py` to ensure only one bot instance runs
- document how to avoid `409 Conflict` errors in the README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest_asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68809cb20f58832a8a46b7669af2879d