### PR TITLE
Fix office selection case sensitivity

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -9,6 +9,7 @@ from utils import (
     register_user,
     is_admin,
     update_user_office,
+    resolve_office_name,
 )
 
 CANCEL_TEXT = "\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434"
@@ -104,8 +105,9 @@ async def get_first_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def get_office(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user_id = update.effective_user.id
-    office = update.message.text.strip()
-    if office not in getattr(config, "OFFICES", {}):
+    office_input = update.message.text.strip()
+    office = resolve_office_name(office_input)
+    if not office:
         await update.message.reply_text(
             "Неверный офис, выберите из списка.", reply_markup=get_office_keyboard()
         )
@@ -138,8 +140,9 @@ async def change_office_start(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 
 async def set_new_office(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    office = update.message.text.strip()
-    if office not in getattr(config, "OFFICES", {}):
+    office_input = update.message.text.strip()
+    office = resolve_office_name(office_input)
+    if not office:
         await update.message.reply_text(
             "Неверный офис, выберите из списка.", reply_markup=get_office_keyboard()
         )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -27,6 +27,19 @@ async def test_registration_flow(app):
 
 
 @pytest.mark.asyncio
+async def test_registration_office_case_insensitive(app):
+    application, sent, tmp = app
+    await application.process_update(make_update(application, "/start"))
+    await application.process_update(make_update(application, "Last"))
+    await application.process_update(make_update(application, "First"))
+    assert sent[-1] == "Выберите офис:"
+    await application.process_update(make_update(application, "main"))
+    assert sent[-1] == "✅ Регистрация успешна."
+    data = json.loads((tmp / "users.json").read_text())
+    assert data[0]["office"] == "Main"
+
+
+@pytest.mark.asyncio
 async def test_take_and_return_book(app):
     application, sent, tmp = app
     # register user

--- a/utils.py
+++ b/utils.py
@@ -44,6 +44,16 @@ def is_admin(user_id: int, office: Optional[str] = None) -> bool:
     return False
 
 
+def resolve_office_name(name: str) -> Optional[str]:
+    """Return canonical office key matching the provided text."""
+    offices = getattr(config, "OFFICES", {})
+    name_clean = name.strip().lower()
+    for office in offices.keys():
+        if office.lower() == name_clean:
+            return office
+    return None
+
+
 def get_user(user_id: int) -> Optional[Dict[str, Any]]:
     """Return user data for the given Telegram ID."""
     users = load_json("users.json")


### PR DESCRIPTION
## Summary
- allow case-insensitive office name checks
- adjust user registration and office change handlers
- test office selection with lower case input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880a3900168832a8f36df6afcc754bf