### PR TITLE
Fix office selection using display names

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,20 +43,44 @@ def _office_admins(name: str) -> List[str]:
 
 OFFICES = {
     # Офис ГК «ОСНОВА» – Москва, ул. Малая Семёновская, д. 9, стр. 3, 2 этаж
-    "NaSemenovskoy": {"admins": _office_admins("NaSemenovskoy")},
+    "NaSemenovskoy": {
+        "name": "На Семёновской",
+        "admins": _office_admins("NaSemenovskoy"),
+    },
     # ООО «БитРу», пл. Семёновская, 1а, 11 этаж БЦ «Соколиная Гора"
     # Используется короткое имя SokolGora
-    "SokolGora": {"admins": _office_admins("SokolGora")},
+    "SokolGora": {
+        "name": "Соколиная Гора",
+        "admins": _office_admins("SokolGora"),
+    },
     # Офис ГК «ОСНОВА» – Москва, ул. Большая Семёновская, д. 32, 3 этаж
-    "Bolshaya32": {"admins": _office_admins("Bolshaya32")},
+    "Bolshaya32": {
+        "name": "Большая 32",
+        "admins": _office_admins("Bolshaya32"),
+    },
     # Центральный офис ГК «ОСНОВА» – Москва, ул. Большая Семёновская, д. 32/7, 2 этаж
-    "Central": {"admins": _office_admins("Central")},
+    "Central": {
+        "name": "Центральный",
+        "admins": _office_admins("Central"),
+    },
     # IT-Технопарк «ФизТехПарк» – Москва, ш. Долгопрудненское, д. 3
-    "FizTechPark": {"admins": _office_admins("FizTechPark")},
+    "FizTechPark": {
+        "name": "ФизТехПарк",
+        "admins": _office_admins("FizTechPark"),
+    },
     # Курорт «ЕРИНО» – поселок Ерино, микрорайон Санаторий, д. 1, стр. 5
-    "Erino": {"admins": _office_admins("Erino")},
+    "Erino": {
+        "name": "Ерино",
+        "admins": _office_admins("Erino"),
+    },
     # ООО «Открытые мастерские» – Москва, ул. Электрозаводская, д. 27, стр. 8
-    "OpenWorkshops": {"admins": _office_admins("OpenWorkshops")},
+    "OpenWorkshops": {
+        "name": "Открытые мастерские",
+        "admins": _office_admins("OpenWorkshops"),
+    },
     # Проектный офис ГК «ОСНОВА» – Москва, ул. Электрозаводская, д. 27, стр. 2
-    "ProjectOffice": {"admins": _office_admins("ProjectOffice")},
+    "ProjectOffice": {
+        "name": "Проектный офис",
+        "admins": _office_admins("ProjectOffice"),
+    },
 }

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -27,7 +27,7 @@ CANCEL_KEYBOARD = ReplyKeyboardMarkup(
 def get_office_keyboard() -> ReplyKeyboardMarkup:
     """Return a keyboard with available office names."""
     offices = getattr(config, "OFFICES", {})
-    keyboard = [[name] for name in offices.keys()]
+    keyboard = [[info.get("name", key)] for key, info in offices.items()]
     keyboard.append([CANCEL_TEXT])
     return ReplyKeyboardMarkup(
         keyboard,

--- a/utils.py
+++ b/utils.py
@@ -48,9 +48,14 @@ def resolve_office_name(name: str) -> Optional[str]:
     """Return canonical office key matching the provided text."""
     offices = getattr(config, "OFFICES", {})
     name_clean = name.strip().lower()
-    for office in offices.keys():
-        if office.lower() == name_clean:
-            return office
+    for key, info in offices.items():
+        if key.lower() == name_clean:
+            return key
+        if str(info.get("name", "")).lower() == name_clean:
+            return key
+        for alias in info.get("aliases", []):
+            if str(alias).lower() == name_clean:
+                return key
     return None
 
 


### PR DESCRIPTION
## Summary
- show display names for offices in keyboards
- resolve office name using canonical key, name, or aliases
- add display names for default offices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880a860fc58832aadc7f609d60655b1