### PR TITLE
Move data to database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ BOT_TOKEN=8186990169:AAE0KQbVwWYSXkGbj8HVwXUvlQZzJF80dzQ
 # Comma separated list of global administrator Telegram IDs
 ADMIN_IDS=7007125219
 
+# Database engine: use "postgres" in production or "sqlite" for local testing
+DB_ENGINE=postgres
+
 # Administrator IDs for specific offices (comma separated)
 OFFICE_SOKOLGORA_ADMINS=1000131763
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This bot requires outgoing HTTPS access to `api.telegram.org`. If the domain is 
 
 ## Usage
 
-Run the bot with:
+Set the `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_HOST` and `DB_PORT` variables to connect to your PostgreSQL instance. Run the bot with:
 
 ```bash
 python main.py
@@ -36,13 +36,13 @@ During any step you can press the "↩️ Назад" button to cancel the curre
 and return to the main menu. Use the `/menu` command at any time to show the main keyboard again.
 Use the "📖 Все книги" button to see a list of all books with their current status.
 Administrators receive additional menu options for managing the library: adding books, generating reports, resetting book status and viewing the list of users.
-All data is stored in `data/users.json` and `data/books.json`.
+All data is stored in a database configured via environment variables. By default the bot expects a PostgreSQL server, but you can set `DB_ENGINE=sqlite` to run with a local SQLite file (used in the tests).
 
 ## Project Structure
 
 - `main.py` – bot startup script.
 - `handlers/` – handlers for user and admin actions.
-- `data/` – JSON files with users and books.
+- Database tables are created automatically in the configured engine.
 - `config.py` – loads configuration from environment variables.
 - `.env.example` – template to create your own `.env`.
 - `utils.py` – utility functions for data access and checks.

--- a/db.py
+++ b/db.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from dotenv import load_dotenv
 import psycopg2
+import sqlite3
 
 # Load environment variables so database configuration works out of the box.
 # We first look for a `.env` file in the project root and load it if present.
@@ -19,22 +20,32 @@ elif os.path.exists(example_path):
 
 # Required database connection settings. These environment variables must be
 # defined or a ``KeyError`` will be raised on import.
-DB_NAME = os.environ["DB_NAME"]
-DB_USER = os.environ["DB_USER"]
-DB_PASSWORD = os.environ["DB_PASSWORD"]
-DB_HOST = os.environ["DB_HOST"]
-DB_PORT = int(os.environ["DB_PORT"])
+DB_ENGINE = os.getenv("DB_ENGINE", "postgres")
+if DB_ENGINE == "sqlite":
+    DB_NAME = os.getenv("DB_NAME", os.path.join(base_dir, "hrbook.db"))
+    DB_USER = DB_PASSWORD = DB_HOST = None
+    DB_PORT = None
+else:
+    DB_NAME = os.environ["DB_NAME"]
+    DB_USER = os.environ["DB_USER"]
+    DB_PASSWORD = os.environ["DB_PASSWORD"]
+    DB_HOST = os.environ["DB_HOST"]
+    DB_PORT = int(os.environ["DB_PORT"])
 
 
 @contextmanager
 def get_conn():
-    conn = psycopg2.connect(
-        dbname=DB_NAME,
-        user=DB_USER,
-        password=DB_PASSWORD,
-        host=DB_HOST,
-        port=DB_PORT,
-    )
+    """Return a database connection context manager."""
+    if DB_ENGINE == "sqlite":
+        conn = sqlite3.connect(DB_NAME)
+    else:
+        conn = psycopg2.connect(
+            dbname=DB_NAME,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            host=DB_HOST,
+            port=DB_PORT,
+        )
     try:
         yield conn
     finally:
@@ -42,34 +53,251 @@ def get_conn():
 
 
 def init_db() -> None:
-    """Create the messages table if it doesn't exist."""
+    """Create required tables if they do not exist."""
     with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                CREATE TABLE IF NOT EXISTS messages (
-                    id SERIAL PRIMARY KEY,
-                    user_id BIGINT,
-                    text TEXT,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
-                """
+        cur = conn.cursor()
+        id_column = (
+            "INTEGER PRIMARY KEY AUTOINCREMENT"
+            if DB_ENGINE == "sqlite"
+            else "SERIAL PRIMARY KEY"
+        )
+        cur.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS messages (
+                id {id_column},
+                user_id BIGINT,
+                text TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
-            conn.commit()
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                telegram_id BIGINT PRIMARY KEY,
+                first_name TEXT,
+                last_name TEXT,
+                office TEXT,
+                role TEXT
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS books (
+                qr_code TEXT PRIMARY KEY,
+                title TEXT,
+                status TEXT,
+                taken_by BIGINT,
+                taken_date TEXT,
+                office TEXT
+            )
+            """
+        )
+        conn.commit()
 
 
 def save_message(user_id: int, text: str) -> None:
     with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                "INSERT INTO messages (user_id, text) VALUES (%s, %s)",
-                (user_id, text),
-            )
-            conn.commit()
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"INSERT INTO messages (user_id, text) VALUES ({placeholder}, {placeholder})",
+            (user_id, text),
+        )
+        conn.commit()
 
 
 def delete_all_messages() -> None:
     with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute("DELETE FROM messages")
-            conn.commit()
+        cur = conn.cursor()
+        cur.execute("DELETE FROM messages")
+        conn.commit()
+
+
+def get_user(telegram_id: int):
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"SELECT telegram_id, first_name, last_name, office, role FROM users WHERE telegram_id = {placeholder}",
+            (telegram_id,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "telegram_id": row[0],
+        "first_name": row[1],
+        "last_name": row[2],
+        "office": row[3],
+        "role": row[4],
+    }
+
+
+def get_user_by_name(first_name: str, last_name: str, office: str):
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"SELECT telegram_id, first_name, last_name, office, role FROM users WHERE first_name = {placeholder} AND last_name = {placeholder} AND office = {placeholder}",
+            (first_name, last_name, office),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "telegram_id": row[0],
+        "first_name": row[1],
+        "last_name": row[2],
+        "office": row[3],
+        "role": row[4],
+    }
+
+
+def save_user(user: dict) -> None:
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"""
+            INSERT INTO users (telegram_id, first_name, last_name, office, role)
+            VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+            ON CONFLICT(telegram_id) DO UPDATE SET
+                first_name=excluded.first_name,
+                last_name=excluded.last_name,
+                office=excluded.office,
+                role=excluded.role
+            """,
+            (
+                user.get("telegram_id"),
+                user.get("first_name"),
+                user.get("last_name"),
+                user.get("office"),
+                user.get("role"),
+            ),
+        )
+        conn.commit()
+
+
+def update_user_office(telegram_id: int, office: str, role: str) -> None:
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"UPDATE users SET office = {placeholder}, role = {placeholder} WHERE telegram_id = {placeholder}",
+            (office, role, telegram_id),
+        )
+        conn.commit()
+
+
+def get_all_users():
+    with get_conn() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT telegram_id, first_name, last_name, office, role FROM users"
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "telegram_id": r[0],
+            "first_name": r[1],
+            "last_name": r[2],
+            "office": r[3],
+            "role": r[4],
+        }
+        for r in rows
+    ]
+
+
+def get_book_by_qr(qr: str):
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"SELECT qr_code, title, status, taken_by, taken_date, office FROM books WHERE qr_code = {placeholder}",
+            (qr,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "qr_code": row[0],
+        "title": row[1],
+        "status": row[2],
+        "taken_by": row[3],
+        "taken_date": row[4],
+        "office": row[5],
+    }
+
+
+def save_book(book: dict) -> None:
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"""
+            INSERT INTO books (qr_code, title, status, taken_by, taken_date, office)
+            VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+            ON CONFLICT(qr_code) DO UPDATE SET
+                title=excluded.title,
+                status=excluded.status,
+                taken_by=excluded.taken_by,
+                taken_date=excluded.taken_date,
+                office=excluded.office
+            """,
+            (
+                book.get("qr_code"),
+                book.get("title"),
+                book.get("status"),
+                book.get("taken_by"),
+                book.get("taken_date"),
+                book.get("office"),
+            ),
+        )
+        conn.commit()
+
+
+def get_user_books(user_id: int):
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"SELECT qr_code, title, status, taken_by, taken_date, office FROM books WHERE taken_by = {placeholder} AND status = 'taken'",
+            (user_id,),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "qr_code": r[0],
+            "title": r[1],
+            "status": r[2],
+            "taken_by": r[3],
+            "taken_date": r[4],
+            "office": r[5],
+        }
+        for r in rows
+    ]
+
+
+def get_books_by_office(office: str):
+    with get_conn() as conn:
+        cur = conn.cursor()
+        placeholder = "?" if DB_ENGINE == "sqlite" else "%s"
+        cur.execute(
+            f"SELECT qr_code, title, status, taken_by, taken_date, office FROM books WHERE office = {placeholder}",
+            (office,),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "qr_code": r[0],
+            "title": r[1],
+            "status": r[2],
+            "taken_by": r[3],
+            "taken_date": r[4],
+            "office": r[5],
+        }
+        for r in rows
+    ]
+

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -5,13 +5,13 @@ from telegram.ext import ConversationHandler, MessageHandler, ContextTypes, filt
 
 from utils import (
     is_admin,
-    load_json,
     save_book,
     get_book_by_qr,
     log_action,
     get_books_by_office,
     get_user,
     extract_qr_from_update,
+    get_all_users,
 )
 from .start import (
     ADMIN_KEYBOARD,
@@ -126,7 +126,7 @@ async def list_users(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     office = user.get("office") if user else None
     if not is_admin(update.effective_user.id, office):
         return
-    users = load_json("users.json")
+    users = get_all_users()
     lines = [
         f'{u.get("last_name")} {u.get("first_name")} - {u.get("office")}'
         for u in users

--- a/handlers/books.py
+++ b/handlers/books.py
@@ -16,7 +16,6 @@ from utils import (
     get_user_books,
     log_action,
     is_admin,
-    load_json,
     get_user,
     get_books_by_office,
     extract_qr_from_update,


### PR DESCRIPTION
## Summary
- store user and book info in a database instead of JSON
- add database helpers for users and books
- update utils and handlers to use new DB functions
- run tests using an SQLite database
- tweak DB initialization for PostgreSQL
- update environment example and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880b4936cb8832a86b5adc80725c1d9