### PR TITLE
Fix event loop init in HRbook main

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ def main() -> None:
         asyncio.run(db.init_db())
     except Exception as exc:
         logging.error("Database unavailable: %s", exc)
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
     application.add_handler(start_handler())
     application.add_handler(get_menu_handler())


### PR DESCRIPTION
## Summary
- ensure event loop exists after running `db.init_db()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880d98fde08832ab4c5b485f0b6d711